### PR TITLE
Fixes an issue in ListObjectsV2::handleRequest().

### DIFF
--- a/dikeHDFS/dikeS3/ListObjectsV2.cpp
+++ b/dikeHDFS/dikeS3/ListObjectsV2.cpp
@@ -178,7 +178,7 @@ void ListObjectsV2::handleRequest(HTTPServerRequest &req, HTTPServerResponse &re
             writer.endElement("", "", XMLString("Key"));
 
             writer.startElement("", "", XMLString("LastModified"));
-            writer.characters(XMLString(Poco::DateTimeFormatter::format(ldt,"%Y-%n-%fT%H:%M:%S.%iZ")));                
+            writer.characters(XMLString(Poco::DateTimeFormatter::format(ldt,"%Y-%n-%eT%H:%M:%S.%iZ")));
             //writer.characters(XMLString("2020-10-27T17:44:12.056Z"));                
             writer.endElement("", "", XMLString("LastModified"));
 


### PR DESCRIPTION
When we are forming the XML for the file LastModified timestamp,
using Poco::DateTimeFormatter::format, use format specifier
for non padded day of the month (%e).
Previously we used a space-padded day of month (%f), which
caused issues on the client side when parsing the day of the month.

For example, a client might see this error:
Cause: java.lang.IllegalArgumentException: Invalid format: "2021-7- 8T16:48:15.874Z" is malformed at " 8T16:48:15.874Z"